### PR TITLE
Issue 18: Recent searches list no longer pushes down search bar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -33,12 +33,19 @@
 }
 
 body {
+    display: flex;
+    flex-direction: column;
     font-family: 'Lobster', cursive;
     font-size: 26px;
     line-height: 1.8;
+    height: 100vh;
     color: var(--primary);
     background-color: var(--secondary);
     background-image: var(--gradient);
+}
+
+footer {
+    margin-top: auto;
 }
 
 h1, h2, h3 {
@@ -136,10 +143,6 @@ section {
     font-size: 26px;
     font-family: 'Courgette', cursive;
     color: var(--primary);
-}
-
-.searchedCocktail {
-    height: 40vw;
 }
 
 .history {

--- a/student-portal.html
+++ b/student-portal.html
@@ -49,7 +49,7 @@
             </div>
         </div>
 
-        <div class="cell small-10 grid-x container">
+        <div class="cell small-10 container">
             <div class="cell">
                 <h3>Search for a drink</h3>
             </div>


### PR DESCRIPTION
By removing the grid-x class from the search bar's wrapper, the search bar no longer moves down with a long list.

Additionally, I removed the 40vw styling since it was causing some spacing issues.

By making the body 100vw and a flex object, I was able to ensure that the footer stays at the bottom of the page. If there is a lot of content on the page, then it will move down so that it does not overlap other things.

Please review the pull request and accept the changes if they're okay! Otherwise, please send it back to me for review.