### PR TITLE
Issue 21: Centre map on main page

### DIFF
--- a/Assets/css/styles.css
+++ b/Assets/css/styles.css
@@ -145,7 +145,7 @@ section {
 }
 
 #google-map {
-   padding: 5vw; 
+   padding-left: 5vw; 
 }
 
 .subscription {

--- a/index.html
+++ b/index.html
@@ -174,10 +174,8 @@
             </div>
     
             <div class="cell small-5" id="google-map">
-                <iframe
-                src="https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d12182.30520634488!2d-74.0652613!3d40.2407219!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sus!4v1561060983193!5m2!1sen!2sus"
-                frameborder="0" style="border:0" allowfullscreen>
-                </iframe> 
+                <h3>Where We Are</h3>
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2886.98066184945!2d-79.38003404804724!3d43.64857067901885!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d4cb3281c78193%3A0x3309c08402897c30!2s64%20Yonge%20St%2C%20Toronto%2C%20ON%2C%20Canada!5e0!3m2!1sen!2sus!4v1611419021662!5m2!1sen!2sus" width="400" height="300" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
             </div>               
         </div>
     </section>


### PR DESCRIPTION
The map now centers in on our fake address at 64 Yonge Street. I added an h3 element, and slightly adjusted the css so that instead of having 5vw padding on all sides, there's only 5vw padding on the left.